### PR TITLE
[minor-change][sql-query-sniffer] handle asterisk substitution 

### DIFF
--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/SQLQuerySniffer.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/SQLQuerySniffer.kt
@@ -151,6 +151,7 @@ class SQLQuerySniffer(config: Config): Rule(config) {
             newQuery = newQuery.replace("$${key}", value)
         }
         return newQuery
+            .replace("*", "ALL")
     }
 
     private fun getClassAttributeStore(params: List<String>): Map<String, Map<String, String>> {


### PR DESCRIPTION
Sql Query Sniffer
During GITHUB comments `*` in queries is being substituted with detekt configs hence replacing it will `ALL`