### PR TITLE
JerseyMethodParameterDefault: fix element for inference

### DIFF
--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/jersey.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/jersey.kt
@@ -53,7 +53,7 @@ class JerseyMethodParameterDefaultValue(config: Config) : Rule(config) {
                 report(
                     CodeSmell(
                         issue = issue,
-                        entity = Entity.from(function),
+                        entity = Entity.from(parameter),
                         message = "probable jersey resource method (${function.name}) has parameter with defaultValue (${parameter.name})"
                     )
                 )

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/JerseyTest.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/JerseyTest.kt
@@ -34,8 +34,8 @@ class JerseyTest {
         val code = TestUtils.readFile("simple05.kt")
         val findings = subject.compileAndLintWithContext(TestUtils.env, code)
         ensureJerseyMethodParameterDefaultValueFindings(findings, listOf(
-            SourceLocation(13, 1),
-            SourceLocation(19, 1)
+            SourceLocation(15, 10),
+            SourceLocation(21, 10)
         ))
     }
 


### PR DESCRIPTION
reviewdog defaults to 'added' lines and function could start anywhere above