### PR TITLE
Detekt: Adding rule to verify if data classes are annotated with JsonIgnoreProperties

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Inspections provided:
    non-blocking alternatives
  - **JerseyMethodParameterDefaultValue**: infer if a probable jersey method contains a parameter with a default value
 - **JerseyMainThreadBlockingCall**: infer if a probable jersey resource method contains a main thread blocking call(runblocking)
+- **JsonIgnorePropertiesOnDataClass**: infer if a data class is not annotated with `@JsonIgnoreProperties(ignoreUnknown=true)`.
 
 ## detekt run
 
@@ -139,3 +140,17 @@ sidekt:
     active: true
     # debug: 'stderr'
 ```
+
+## JsonIgnorePropertiesOnDataClass
+```yml
+sidekt:
+   JsonIgnorePropertiesOnDataClass:
+    active: true
+    excludes: "com.example.excluded, another.package"
+    # debug: 'stderr'
+```
+#### JsonIgnorePropertiesOnDataClass
+This rule enforces the use of the `@JsonIgnoreProperties` annotation on all data classes within the codebase. 
+Data classes must be annotated with `@JsonIgnoreProperties(ignoreUnknown = true)` to ensure compatibility with JSON deserialization.
+### excludes
+This allows exclusion of certain packages where you don't want to run the check

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/SideKtRuleSetProvider.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/SideKtRuleSetProvider.kt
@@ -18,7 +18,8 @@ class SideKtRuleSetProvider : RuleSetProvider {
             ResourceOnboardedOnAsec(config),
             SQLQuerySniffer(config),
             ImageQuality(config),
-            ImageWidth(config)
+            ImageWidth(config),
+            JsonIgnorePropertiesOnDataClass(config)
         )
     )
 }

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -25,7 +25,7 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
 
     companion object {
         private const val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
-        private const val JSON_IGNORE_ANNOTATION_IMPORT_NAME = "com.fasterxml.jackson.annotation"
+        private const val JSON_IGNORE_ANNOTATION_PACKAGE_NAME = "com.fasterxml.jackson.annotation"
         private const val IGNORE_UNKNOWN = "ignoreUnknown"
     }
 
@@ -75,7 +75,7 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
                     importDirective.importPath?.pathStr
                 }.toSet()
 
-                fullyQualifiedImportNames.any { it.startsWith(JSON_IGNORE_ANNOTATION_IMPORT_NAME) } &&
+                fullyQualifiedImportNames.any { it.startsWith(JSON_IGNORE_ANNOTATION_PACKAGE_NAME) } &&
                         annotation.shortName?.asString() == JSON_IGNORE_ANNOTATION &&
                         annotation.valueArguments.any {
                             it.getArgumentExpression()?.text == true.toString() &&

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -25,8 +25,7 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
 
     companion object {
         private const val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
-        private const val JSON_IGNORE_ANNOTATION_FULL_QUALIFIED_NAME =
-            "com.fasterxml.jackson.annotation.JsonIgnoreProperties"
+        private const val JSON_IGNORE_ANNOTATION_IMPORT_NAME = "com.fasterxml.jackson.annotation"
         private const val IGNORE_UNKNOWN = "ignoreUnknown"
     }
 
@@ -76,7 +75,7 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
                     importDirective.importPath?.pathStr
                 }.toSet()
 
-                JSON_IGNORE_ANNOTATION_FULL_QUALIFIED_NAME in fullyQualifiedImportNames &&
+                fullyQualifiedImportNames.any { it.startsWith(JSON_IGNORE_ANNOTATION_IMPORT_NAME) } &&
                         annotation.shortName?.asString() == JSON_IGNORE_ANNOTATION &&
                         annotation.valueArguments.any {
                             it.getArgumentExpression()?.text == true.toString() &&

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -4,6 +4,12 @@ import io.github.thewisenerd.linters.sidekt.helpers.Debugger
 import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.*
 
+/**
+ * This rule enforces the use of the `@JsonIgnoreProperties` annotation on all data classes within the codebase.
+ *
+ * Severity: Maintainability
+ * Debt: 5min
+ */
 class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
 
     companion object {

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -1,13 +1,7 @@
 package io.github.thewisenerd.linters.sidekt.rules
 
 import io.github.thewisenerd.linters.sidekt.helpers.Debugger
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
+import io.gitlab.arturbosch.detekt.api.*
 import org.jetbrains.kotlin.psi.KtClass
 
 /**

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -9,18 +9,35 @@ import org.jetbrains.kotlin.psi.KtClass
  *
  * Severity: Maintainability
  * Debt: 5min
+ *
+ * Usage:
+ * JsonIgnorePropertiesOnDataClass:
+ *   active: true
+ *   excludes: "com.example.excluded, another.package"
  */
 class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
 
     companion object {
-        const val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
-        const val IGNORE_UNKNOWN = "ignoreUnknown"
+        private const val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
+        private const val IGNORE_UNKNOWN = "ignoreUnknown"
     }
 
     private val debugStream by lazy {
         valueOrNull<String>("debug")?.let {
             Debugger.getOutputStreamForDebugger(it)
         }
+    }
+
+    private fun readConfig(key: String, initial: Set<String>? = null): Set<String> {
+        val result = initial?.toMutableSet() ?: mutableSetOf()
+        valueOrNull<ArrayList<String>>(key)?.let {
+            result.addAll(it)
+        }
+        return result
+    }
+
+    private val excludedPackages: Set<String> by lazy {
+        readConfig("excludedPackages")
     }
 
     override val issue: Issue = Issue(
@@ -33,15 +50,24 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
     override fun visitClass(kclass: KtClass) {
         super.visitClass(kclass)
         val dbg = Debugger.make(JsonIgnorePropertiesOnDataClass::class.java.simpleName, debugStream)
+
+        val packageName = kclass.containingKtFile.packageFqName.asString()
+
+        // Check if the current class's package is in the excluded list
+        if (excludedPackages.any { packageName.startsWith(it) }) {
+            dbg.i("Package $packageName is excluded under JsonIgnoreProperties check")
+            return
+        }
+
         // Check if the class is a data class
         if (kclass.isData()) {
             // Check if @JsonIgnoreProperties(ignoreUnknown = true) annotation exists
             val hasJsonIgnoreProperties = kclass.annotationEntries.any { annotation ->
                 annotation.shortName?.asString() == JSON_IGNORE_ANNOTATION &&
-                    annotation.valueArguments.any {
-                        it.getArgumentExpression()?.text == true.toString() &&
-                            it.getArgumentName()?.asName.toString() == IGNORE_UNKNOWN
-                    }
+                        annotation.valueArguments.any {
+                            it.getArgumentExpression()?.text == true.toString() &&
+                                    it.getArgumentName()?.asName.toString() == IGNORE_UNKNOWN
+                        }
             }
 
             // Report if annotation is missing

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -2,7 +2,7 @@ package io.github.thewisenerd.linters.sidekt.rules
 
 import io.github.thewisenerd.linters.sidekt.helpers.Debugger
 import io.gitlab.arturbosch.detekt.api.*
-import org.jetbrains.kotlin.psi.*
+import org.jetbrains.kotlin.psi.KtClass
 
 /**
  * This rule enforces the use of the `@JsonIgnoreProperties` annotation on all data classes within the codebase.
@@ -13,7 +13,8 @@ import org.jetbrains.kotlin.psi.*
 class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
 
     companion object {
-        val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
+        const val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
+        const val IGNORE_UNKNOWN = "ignoreUnknown"
     }
 
     private val debugStream by lazy {
@@ -25,18 +26,22 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
     override val issue: Issue = Issue(
         id = JsonIgnorePropertiesOnDataClass::class.java.simpleName,
         severity = Severity.Maintainability,
-        description = "JsonIgnoreProperties is not annotated on the data class",
-        debt = Debt.FIVE_MINS,
+        description = "JsonIgnoreProperties(ignoreUnknown = true) is not annotated on the data class",
+        debt = Debt.FIVE_MINS
     )
 
-    override fun visitClass(klass: KtClass) {
-        super.visitClass(klass)
+    override fun visitClass(kclass: KtClass) {
+        super.visitClass(kclass)
         val dbg = Debugger.make(JsonIgnorePropertiesOnDataClass::class.java.simpleName, debugStream)
         // Check if the class is a data class
-        if (klass.isData()) {
-            // Check if @JsonIgnoreProperties annotation exists
-            val hasJsonIgnoreProperties = klass.annotationEntries.any { annotation ->
-                annotation.shortName?.asString() == JSON_IGNORE_ANNOTATION
+        if (kclass.isData()) {
+            // Check if @JsonIgnoreProperties(ignoreUnknown = true) annotation exists
+            val hasJsonIgnoreProperties = kclass.annotationEntries.any { annotation ->
+                annotation.shortName?.asString() == JSON_IGNORE_ANNOTATION &&
+                    annotation.valueArguments.any {
+                        it.getArgumentExpression()?.text == true.toString() &&
+                            it.getArgumentName()?.asName.toString() == IGNORE_UNKNOWN
+                    }
             }
 
             // Report if annotation is missing
@@ -45,9 +50,9 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
                 report(
                     CodeSmell(
                         issue = issue,
-                        entity = Entity.from(klass),
-                        message = "Data class '${klass.name}' should be annotated with @JsonIgnoreProperties(ignoreUnknown = true)",
-                    ),
+                        entity = Entity.from(kclass),
+                        message = "Data class '${kclass.name}' should be annotated with @JsonIgnoreProperties(ignoreUnknown = true)"
+                    )
                 )
             } else {
                 dbg.i("JsonIgnoreProperties annotation is present for data class ${kclass.name}")

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -37,7 +37,7 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
     }
 
     private val excludedPackages: Set<String> by lazy {
-        readConfig("excludedPackages")
+        readConfig("excludes")
     }
 
     override val issue: Issue = Issue(

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -17,7 +17,7 @@ class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
     }
 
     override val issue: Issue = Issue(
-        id = JsonIgnoreOnDataClass::class.java.simpleName,
+        id = JsonIgnorePropertiesOnDataClass::class.java.simpleName,
         severity = Severity.Maintainability,
         description = "JsonIgnoreProperties is not annotated on the data class",
         debt = Debt.FIVE_MINS,

--- a/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
+++ b/src/main/kotlin/io/github/thewisenerd/linters/sidekt/rules/JsonIgnorePropertiesOnDataClass.kt
@@ -1,0 +1,51 @@
+package io.github.thewisenerd.linters.sidekt.rules
+
+import io.github.thewisenerd.linters.sidekt.helpers.Debugger
+import io.gitlab.arturbosch.detekt.api.*
+import org.jetbrains.kotlin.psi.*
+
+class JsonIgnorePropertiesOnDataClass(config: Config) : Rule(config) {
+
+    companion object {
+        val JSON_IGNORE_ANNOTATION = "JsonIgnoreProperties"
+    }
+
+    private val debugStream by lazy {
+        valueOrNull<String>("debug")?.let {
+            Debugger.getOutputStreamForDebugger(it)
+        }
+    }
+
+    override val issue: Issue = Issue(
+        id = JsonIgnoreOnDataClass::class.java.simpleName,
+        severity = Severity.Maintainability,
+        description = "JsonIgnoreProperties is not annotated on the data class",
+        debt = Debt.FIVE_MINS,
+    )
+
+    override fun visitClass(klass: KtClass) {
+        super.visitClass(klass)
+        val dbg = Debugger.make(JsonIgnorePropertiesOnDataClass::class.java.simpleName, debugStream)
+        // Check if the class is a data class
+        if (klass.isData()) {
+            // Check if @JsonIgnoreProperties annotation exists
+            val hasJsonIgnoreProperties = klass.annotationEntries.any { annotation ->
+                annotation.shortName?.asString() == JSON_IGNORE_ANNOTATION
+            }
+
+            // Report if annotation is missing
+            if (!hasJsonIgnoreProperties) {
+                dbg.i("JsonIgnoreProperties annotation is missed for data class ${kclass.name}")
+                report(
+                    CodeSmell(
+                        issue = issue,
+                        entity = Entity.from(klass),
+                        message = "Data class '${klass.name}' should be annotated with @JsonIgnoreProperties(ignoreUnknown = true)",
+                    ),
+                )
+            } else {
+                dbg.i("JsonIgnoreProperties annotation is present for data class ${kclass.name}")
+            }
+        }
+    }
+}

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
@@ -39,7 +39,7 @@ class TestJsonIgnorePropOnDataClass {
             return when (key) {
                 "active" -> true as? T
                 "debug" -> "stderr" as? T
-                "excludedPackages" -> arrayListOf("io.github.thewisenerd", "io.github.thewisenerd.linters") as? T
+                "excludes" -> arrayListOf("io.github.thewisenerd", "io.github.thewisenerd.linters") as? T
                 else -> null
             }
         }

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
@@ -62,6 +62,42 @@ class TestJsonIgnorePropOnDataClass {
     }
 
     @Test
+    fun testDataClassesWildCardImport() {
+        val code = TestUtils.readFile("TestJsonIgnorePropertiesOnDataClass.kt").replace(
+            "import com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+            "import com.fasterxml.jackson.annotation.*"
+        )
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureJsonIgnorePropOnDataClassFindings(
+            findings,
+            listOf(
+                SourceLocation(11, 1),
+                SourceLocation(16, 1),
+                SourceLocation(21, 1)
+            )
+        )
+    }
+
+    @Test
+    fun testDataClassesIncorrectImport() {
+        val code = TestUtils.readFile("TestJsonIgnorePropertiesOnDataClass.kt").replace(
+            "import com.fasterxml.jackson.annotation.JsonIgnoreProperties",
+            "import org.apache.tinkerpop.shaded.jackson.annotation.JsonIgnoreProperties"
+        )
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureJsonIgnorePropOnDataClassFindings(
+            findings,
+            listOf(
+                SourceLocation(5, 1),
+                SourceLocation(11, 1),
+                SourceLocation(16, 1),
+                SourceLocation(21, 1),
+                SourceLocation(27, 1)
+            )
+        )
+    }
+
+    @Test
     fun testDataClassesWithExcludedPackage() {
         val code = TestUtils.readFile("TestJsonIgnorePropertiesOnDataClass.kt")
         val findings = subjectWithExcludedPackage.compileAndLintWithContext(TestUtils.env, code)

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
@@ -14,7 +14,7 @@ class TestJsonIgnorePropOnDataClass {
 
         private fun ensureJsonIgnorePropOnDataClassFindings(
             findings: List<Finding>,
-            requiredFindings: List<SourceLocation>,
+            requiredFindings: List<SourceLocation>
         ) = TestUtils.ensureFindings(jsonIgnorePropOnDataClass, findings, requiredFindings)
     }
 
@@ -34,14 +34,15 @@ class TestJsonIgnorePropOnDataClass {
 
     @Test
     fun testDataClasses() {
-        val code = TestUtils.readFile("TestJsonIgnorePropOnDataClass.kt")
+        val code = TestUtils.readFile("TestJsonIgnorePropertiesOnDataClass.kt")
         val findings = subject.compileAndLintWithContext(TestUtils.env, code)
         ensureJsonIgnorePropOnDataClassFindings(
             findings,
             listOf(
                 SourceLocation(9, 1),
                 SourceLocation(14, 1),
-            ),
+                SourceLocation(19, 1)
+            )
         )
     }
 }

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
@@ -30,7 +30,22 @@ class TestJsonIgnorePropOnDataClass {
             }
         }
     }
+
+    private val testConfigWithExcludedPackage = object : Config {
+        override fun subConfig(key: String): Config = this
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> valueOrNull(key: String): T? {
+            return when (key) {
+                "active" -> true as? T
+                "debug" -> "stderr" as? T
+                "excludedPackages" -> arrayListOf("io.github.thewisenerd", "io.github.thewisenerd.linters") as? T
+                else -> null
+            }
+        }
+    }
     private val subject = JsonIgnorePropertiesOnDataClass(testConfig)
+    private val subjectWithExcludedPackage = JsonIgnorePropertiesOnDataClass(testConfigWithExcludedPackage)
 
     @Test
     fun testDataClasses() {
@@ -39,10 +54,20 @@ class TestJsonIgnorePropOnDataClass {
         ensureJsonIgnorePropOnDataClassFindings(
             findings,
             listOf(
-                SourceLocation(9, 1),
-                SourceLocation(14, 1),
-                SourceLocation(19, 1)
+                SourceLocation(11, 1),
+                SourceLocation(16, 1),
+                SourceLocation(21, 1)
             )
+        )
+    }
+
+    @Test
+    fun testDataClassesWithExcludedPackage() {
+        val code = TestUtils.readFile("TestJsonIgnorePropertiesOnDataClass.kt")
+        val findings = subjectWithExcludedPackage.compileAndLintWithContext(TestUtils.env, code)
+        ensureJsonIgnorePropOnDataClassFindings(
+            findings,
+            emptyList()
         )
     }
 }

--- a/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
+++ b/src/test/kotlin/io/github/thewisenerd/linters/sidekt/TestJsonIgnorePropOnDataClass.kt
@@ -1,0 +1,47 @@
+package io.github.thewisenerd.linters.sidekt
+
+import io.github.thewisenerd.linters.sidekt.rules.JsonIgnorePropertiesOnDataClass
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.api.Finding
+import io.gitlab.arturbosch.detekt.api.SourceLocation
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.junit.Test
+
+class TestJsonIgnorePropOnDataClass {
+
+    companion object {
+        private val jsonIgnorePropOnDataClass = JsonIgnorePropertiesOnDataClass::class.java.simpleName
+
+        private fun ensureJsonIgnorePropOnDataClassFindings(
+            findings: List<Finding>,
+            requiredFindings: List<SourceLocation>,
+        ) = TestUtils.ensureFindings(jsonIgnorePropOnDataClass, findings, requiredFindings)
+    }
+
+    private val testConfig = object : Config {
+        override fun subConfig(key: String): Config = this
+
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : Any> valueOrNull(key: String): T? {
+            return when (key) {
+                "active" -> true as? T
+                "debug" -> "stderr" as? T
+                else -> null
+            }
+        }
+    }
+    private val subject = JsonIgnorePropertiesOnDataClass(testConfig)
+
+    @Test
+    fun testDataClasses() {
+        val code = TestUtils.readFile("TestJsonIgnorePropOnDataClass.kt")
+        val findings = subject.compileAndLintWithContext(TestUtils.env, code)
+        ensureJsonIgnorePropOnDataClassFindings(
+            findings,
+            listOf(
+                SourceLocation(9, 1),
+                SourceLocation(14, 1),
+            ),
+        )
+    }
+}

--- a/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
+++ b/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
@@ -1,0 +1,23 @@
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class SampleWithAnnotation(
+    val firstVariable: String,
+    val secondVariable: Int,
+)
+
+data class SampleWithoutAnnotation(
+    val firstVariable: String,
+    val secondVariable: Int,
+)
+
+data class SampleWithoutAnnotationWithJvmOverloads @JvmOverloads constructor(
+    val firstVariable: String,
+    val secondVariable: Int,
+)
+
+@JsonIgnoreProperties(allowSetters = true)
+data class SampleWithAnnotationV2(
+    val firstVariable: String,
+    val secondVariable: Int,
+)

--- a/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
+++ b/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
@@ -3,21 +3,21 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class SampleWithAnnotation(
     val firstVariable: String,
-    val secondVariable: Int,
+    val secondVariable: Int
 )
 
 data class SampleWithoutAnnotation(
     val firstVariable: String,
-    val secondVariable: Int,
+    val secondVariable: Int
 )
 
 data class SampleWithoutAnnotationWithJvmOverloads @JvmOverloads constructor(
     val firstVariable: String,
-    val secondVariable: Int,
+    val secondVariable: Int = 1
 )
 
 @JsonIgnoreProperties(allowSetters = true)
-data class SampleWithAnnotationV2(
+data class SampleWithWrongAnnotation(
     val firstVariable: String,
-    val secondVariable: Int,
+    val secondVariable: Int
 )

--- a/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
+++ b/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
@@ -21,3 +21,9 @@ data class SampleWithWrongAnnotation(
     val firstVariable: String,
     val secondVariable: Int
 )
+
+@JsonIgnoreProperties(allowSetters = true, ignoreUnknown = true)
+data class SampleWithMultipleAnnotation(
+    val firstVariable: String,
+    val secondVariable: Int
+)

--- a/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
+++ b/src/test/resources/TestJsonIgnorePropertiesOnDataClass.kt
@@ -1,3 +1,5 @@
+package io.github.thewisenerd.linters.sidekt
+
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)


### PR DESCRIPTION
This rule helps identify data classes which are being added without the `@JsonIgnoreProperties(ignoreUnknown=true)` annotation. If required we can also exclude packages from this check. 

```kotlin
// this would be allowed
@JsonIgnoreProperties(ignoreUnknown=true)
data class Car (
     val type: String
)

// this would not be allowed
data class Truck (
     val type: String
)
```

```Yaml
-- Sample Usage
JsonIgnorePropertiesOnDataClass:
  active: true
  excludes: "com.example.excluded., another.package."
```
Tested using unit tests 
<img width="1329" alt="image" src="https://github.com/user-attachments/assets/04a5f2c9-e2db-44e5-876e-2bdc35890cc8">
